### PR TITLE
Extract ExternalServices and TumblerClientConfiguration parent types

### DIFF
--- a/NTumbleBit.Tests/TumblerServerTester.cs
+++ b/NTumbleBit.Tests/TumblerServerTester.cs
@@ -1,9 +1,8 @@
 ﻿using Microsoft.AspNetCore.Hosting;
-using TCPServer;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.AspNetCore.Server.Kestrel;
 using NBitcoin;
+using NBitcoin.RPC;
 using NTumbleBit.ClassicTumbler;
 using NTumbleBit.ClassicTumbler.CLI;
 using NTumbleBit.ClassicTumbler.Client;
@@ -17,267 +16,280 @@ using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
+using NTumbleBit.Services;
 
 namespace NTumbleBit.Tests
 {
-	public class TumblerServerTester : IDisposable
-	{
-		public static TumblerServerTester Create([CallerMemberNameAttribute]string caller = null)
-		{
-			return new TumblerServerTester(caller);
-		}
-		public TumblerServerTester(string directory)
-		{
-			try
-			{
+    public class TumblerServerTester : IDisposable
+    {
+        public static TumblerServerTester Create([CallerMemberNameAttribute]string caller = null)
+        {
+            return new TumblerServerTester(caller);
+        }
+        public TumblerServerTester(string directory)
+        {
+            try
+            {
 
-				var rootTestData = "TestData";
-				directory = rootTestData + "/" + directory;
-				_Directory = directory;
-				if(!Directory.Exists(rootTestData))
-					Directory.CreateDirectory(rootTestData);
+                var rootTestData = "TestData";
+                directory = rootTestData + "/" + directory;
+                _Directory = directory;
+                if (!Directory.Exists(rootTestData))
+                    Directory.CreateDirectory(rootTestData);
 
-				if(!TryDelete(directory, false))
-				{
-					foreach(var process in Process.GetProcessesByName("bitcoind"))
-					{
-						if(process.MainModule.FileName.Replace("\\", "/").StartsWith(Path.GetFullPath(rootTestData).Replace("\\", "/"), StringComparison.Ordinal))
-						{
-							process.Kill();
-							process.WaitForExit();
-						}
-					}
-					TryDelete(directory, true);
-				}
+                if (!TryDelete(directory, false))
+                {
+                    foreach (var process in Process.GetProcessesByName("bitcoind"))
+                    {
+                        if (process.MainModule.FileName.Replace("\\", "/").StartsWith(Path.GetFullPath(rootTestData).Replace("\\", "/"), StringComparison.Ordinal))
+                        {
+                            process.Kill();
+                            process.WaitForExit();
+                        }
+                    }
+                    TryDelete(directory, true);
+                }
 
-				_NodeBuilder = NodeBuilder.Create(directory);
-				_TumblerNode = _NodeBuilder.CreateNode(false);
-				_AliceNode = _NodeBuilder.CreateNode(false);
-				_BobNode = _NodeBuilder.CreateNode(false);
+                _NodeBuilder = NodeBuilder.Create(directory);
+                _TumblerNode = _NodeBuilder.CreateNode(false);
+                _AliceNode = _NodeBuilder.CreateNode(false);
+                _BobNode = _NodeBuilder.CreateNode(false);
 
-				Directory.CreateDirectory(directory);
+                Directory.CreateDirectory(directory);
 
-				_NodeBuilder.StartAll();
+                _NodeBuilder.StartAll();
 
-				SyncNodes();
-				
-				var conf = new TumblerConfiguration();
-				conf.DataDir = Path.Combine(directory, "server");
-				Directory.CreateDirectory(conf.DataDir);
-				File.WriteAllBytes(Path.Combine(conf.DataDir, "Tumbler.pem"), TestKeys.Default.ToBytes());
-				File.WriteAllBytes(Path.Combine(conf.DataDir, "Voucher.pem"), TestKeys.Default2.ToBytes());
-				conf.RPC.Url = TumblerNode.CreateRPCClient().Address;
-				var creds = ExtractCredentials(File.ReadAllText(_TumblerNode.Config));
-				conf.RPC.User = creds.Item1;
-				conf.RPC.Password = creds.Item2;
-				conf.Network = Network.RegTest;
-				conf.Listen = new System.Net.IPEndPoint(IPAddress.Parse("127.0.0.1"), 5000);
-				conf.AllowInsecure = true;
-				conf.ClassicTumblerParameters.FakePuzzleCount /= 4;
-				conf.ClassicTumblerParameters.FakeTransactionCount /= 4;
-				conf.ClassicTumblerParameters.RealTransactionCount /= 4;
-				conf.ClassicTumblerParameters.RealPuzzleCount /= 4;
-				conf.ClassicTumblerParameters.CycleGenerator.FirstCycle.Start = 105;
+                SyncNodes();
 
-				var runtime = TumblerRuntime.FromConfiguration(conf, new AcceptAllClientInteraction());
-				_Host = new WebHostBuilder()
-					.UseAppConfiguration(runtime)
-					.UseContentRoot(Path.GetFullPath(directory))
-					.UseStartup<Startup>()
-					.Build();
+                var conf = new TumblerConfiguration();
+                conf.DataDir = Path.Combine(directory, "server");
 
-				_Host.Start();
-				ServerRuntime = runtime;
+                Directory.CreateDirectory(conf.DataDir);
+                File.WriteAllBytes(Path.Combine(conf.DataDir, "Tumbler.pem"), TestKeys.Default.ToBytes());
+                File.WriteAllBytes(Path.Combine(conf.DataDir, "Voucher.pem"), TestKeys.Default2.ToBytes());
+                conf.RPC.Url = TumblerNode.CreateRPCClient().Address;
+                var creds = ExtractCredentials(File.ReadAllText(_TumblerNode.Config));
+                conf.RPC.User = creds.Item1;
+                conf.RPC.Password = creds.Item2;
+                conf.Network = Network.RegTest;
+                conf.Listen = new System.Net.IPEndPoint(IPAddress.Parse("127.0.0.1"), 5000);
+                conf.AllowInsecure = true;
+                conf.DBreezeRepository = new DBreezeRepository(Path.Combine(conf.DataDir, "db2"));
+                conf.Tracker = new Tracker(conf.DBreezeRepository, conf.Network);
 
-				//Overrides server fee
-				((RPCFeeService)runtime.Services.FeeService).FallBackFeeRate = new FeeRate(Money.Satoshis(100), 1);
+                conf.ClassicTumblerParameters.FakePuzzleCount /= 4;
+                conf.ClassicTumblerParameters.FakeTransactionCount /= 4;
+                conf.ClassicTumblerParameters.RealTransactionCount /= 4;
+                conf.ClassicTumblerParameters.RealPuzzleCount /= 4;
+                conf.ClassicTumblerParameters.CycleGenerator.FirstCycle.Start = 105;
 
+                RPCClient rpc = conf.RPC.ConfigureRPCClient(conf.Network);
+                conf.Services = ExternalServices.CreateFromRPCClient(rpc, conf.DBreezeRepository, conf.Tracker);
 
-				var clientConfig = new TumblerClientConfiguration();
-				clientConfig.DataDir = Path.Combine(directory, "client");
-				clientConfig.AllowInsecure = true;
-				Directory.CreateDirectory(clientConfig.DataDir);
-				clientConfig.Network = conf.Network;
-				clientConfig.CheckIp = false;
-				clientConfig.OutputWallet.KeyPath = new KeyPath("0");
-				clientConfig.OutputWallet.RootKey = new ExtKey().Neuter().GetWif(conf.Network);
-				clientConfig.RPCArgs.Url = AliceNode.CreateRPCClient().Address;
-				creds = ExtractCredentials(File.ReadAllText(AliceNode.Config));
-				clientConfig.RPCArgs.User = creds.Item1;
-				clientConfig.RPCArgs.Password = creds.Item2;
-				clientConfig.TumblerServer = runtime.TumblerUris.First();
+                var runtime = TumblerRuntime.FromConfiguration(conf, new AcceptAllClientInteraction());
+                _Host = new WebHostBuilder()
+                    .UseAppConfiguration(runtime)
+                    .UseContentRoot(Path.GetFullPath(directory))
+                    .UseStartup<Startup>()
+                    .Build();
 
-				ClientRuntime = TumblerClientRuntime.FromConfiguration(clientConfig, new AcceptAllClientInteraction());
+                _Host.Start();
+                ServerRuntime = runtime;
 
-				//Overrides client fee
-				((RPCFeeService)ClientRuntime.Services.FeeService).FallBackFeeRate = new FeeRate(Money.Satoshis(50), 1);
-			}
-			catch { Dispose(); throw; }
-		}
-
-		public PaymentStateMachine CreateStateMachine()
-		{
-			return new PaymentStateMachine(ClientRuntime);
-		}
-
-		private Tuple<string, string> ExtractCredentials(string config)
-		{
-			var user = Regex.Match(config, "rpcuser=([^\r\n]*)");
-			var pass = Regex.Match(config, "rpcpassword=([^\r\n]*)");
-			return Tuple.Create(user.Groups[1].Value, pass.Groups[1].Value);
-		}
-
-		public TumblerRuntime ServerRuntime
-		{
-			get; set;
-		}
-
-		public void MineTo(CoreNode node, CycleParameters cycle, CyclePhase phase, bool end = false, int offset = 0)
-		{
-			var height = node.CreateRPCClient().GetBlockCount();
-			var periodStart = end ? cycle.GetPeriods().GetPeriod(phase).End : cycle.GetPeriods().GetPeriod(phase).Start;
-			var blocksToFind = periodStart - height + offset;
-			if(blocksToFind <= 0)
-				return;
-
-			node.FindBlock(blocksToFind);
-			SyncNodes();
-		}
-
-		public void RefreshWalletCache()
-		{
-			if(ClientRuntime != null)
-				ClientRuntime.Services.BlockExplorerService.WaitBlock(uint256.Zero, default(CancellationToken));
-			if(ServerRuntime != null)
-				ServerRuntime.Services.BlockExplorerService.WaitBlock(uint256.Zero, default(CancellationToken));
-		}
-
-		public TumblerClientRuntime ClientRuntime
-		{
-			get; set;
-		}
-
-		public void SyncNodes()
-		{
-			foreach(var node in NodeBuilder.Nodes)
-			{
-				foreach(var node2 in NodeBuilder.Nodes)
-				{
-					if(node != node2)
-						node.Sync(node2, true);
-				}
-			}
-			RefreshWalletCache();
-		}
-
-		private static bool TryDelete(string directory, bool throws)
-		{
-			try
-			{
-				Utils.DeleteRecursivelyWithMagicDust(directory);
-				return true;
-			}
-			catch(DirectoryNotFoundException)
-			{
-				return true;
-			}
-			catch(Exception)
-			{
-				if(throws)
-					throw;
-			}
-			return false;
-		}
-
-		private readonly CoreNode _TumblerNode;
-		public CoreNode TumblerNode
-		{
-			get
-			{
-				return _TumblerNode;
-			}
-		}
-
-		private NodeBuilder _NodeBuilder;
-		public NodeBuilder NodeBuilder
-		{
-			get
-			{
-				return _NodeBuilder;
-			}
-		}
-
-		private IWebHost _Host;
-		public IWebHost Host
-		{
-			get
-			{
-				return _Host;
-			}
-		}
-
-		public Uri Address
-		{
-			get
-			{
-				var address = ((IServer)(_Host.Services.GetService(typeof(IServer)))).Features.Get<IServerAddressesFeature>().Addresses.FirstOrDefault();
-				var builder = new UriBuilder(address);
-				builder.Path = $"api/v1/tumblers/{ServerRuntime.ClassicTumblerParameters.GetHash()}";
-				return builder.Uri;
-			}
-		}
-
-		private readonly string _Directory;
-		private readonly CoreNode _AliceNode;
-		public CoreNode AliceNode
-		{
-			get
-			{
-				return _AliceNode;
-			}
-		}
+                //Overrides server fee
+                ((RPCFeeService)runtime.Services.FeeService).FallBackFeeRate = new FeeRate(Money.Satoshis(100), 1);
 
 
-		private readonly CoreNode _BobNode;
-		public CoreNode BobNode
-		{
-			get
-			{
-				return _BobNode;
-			}
-		}
+                var clientConfig = new TumblerClientConfiguration();
+                clientConfig.DataDir = Path.Combine(directory, "client");
+                clientConfig.AllowInsecure = true;
+                Directory.CreateDirectory(clientConfig.DataDir);
+                clientConfig.Network = conf.Network;
+                clientConfig.CheckIp = false;
+                clientConfig.OutputWallet.KeyPath = new KeyPath("0");
+                clientConfig.OutputWallet.RootKey = new ExtKey().Neuter().GetWif(conf.Network);
+                clientConfig.RPCArgs.Url = AliceNode.CreateRPCClient().Address;
+                creds = ExtractCredentials(File.ReadAllText(AliceNode.Config));
+                clientConfig.RPCArgs.User = creds.Item1;
+                clientConfig.RPCArgs.Password = creds.Item2;
+                clientConfig.DBreezeRepository = new DBreezeRepository(Path.Combine(clientConfig.DataDir, "db2"));
+                clientConfig.Tracker = new Tracker(clientConfig.DBreezeRepository, clientConfig.Network);
+                clientConfig.TumblerServer = runtime.TumblerUris.First();
 
-		public string BaseDirectory
-		{
-			get
-			{
-				return _Directory;
-			}
-		}
+                RPCClient rpcClient = clientConfig.RPCArgs.ConfigureRPCClient(clientConfig.Network);
+                clientConfig.Services = ExternalServices.CreateFromRPCClient(rpcClient, clientConfig.DBreezeRepository, clientConfig.Tracker);
+                clientConfig.DestinationWallet = new ClientDestinationWallet(clientConfig.OutputWallet.RootKey, clientConfig.OutputWallet.KeyPath, clientConfig.DBreezeRepository, clientConfig.Network);
+                ClientRuntime = TumblerClientRuntime.FromConfiguration(clientConfig, new AcceptAllClientInteraction());
 
-		public void Dispose()
-		{
-			if(_Host != null)
-			{
+                //Overrides client fee
+                ((RPCFeeService)ClientRuntime.Services.FeeService).FallBackFeeRate = new FeeRate(Money.Satoshis(50), 1);
+            }
+            catch { Dispose(); throw; }
+        }
 
-				_Host.Dispose();
-				_Host = null;
-			}
-			if(_NodeBuilder != null)
-			{
-				_NodeBuilder.Dispose();
-				_NodeBuilder = null;
-			}
-			if(ClientRuntime != null)
-			{
-				ClientRuntime.Dispose();
-				ClientRuntime = null;
-			}
-			if(ServerRuntime != null)
-			{
-				ServerRuntime.Dispose();
-				ServerRuntime = null;
-			}
-		}
-	}
+        public PaymentStateMachine CreateStateMachine()
+        {
+            return new PaymentStateMachine(ClientRuntime);
+        }
+
+        private Tuple<string, string> ExtractCredentials(string config)
+        {
+            var user = Regex.Match(config, "rpcuser=([^\r\n]*)");
+            var pass = Regex.Match(config, "rpcpassword=([^\r\n]*)");
+            return Tuple.Create(user.Groups[1].Value, pass.Groups[1].Value);
+        }
+
+        public TumblerRuntime ServerRuntime
+        {
+            get; set;
+        }
+
+        public void MineTo(CoreNode node, CycleParameters cycle, CyclePhase phase, bool end = false, int offset = 0)
+        {
+            var height = node.CreateRPCClient().GetBlockCount();
+            var periodStart = end ? cycle.GetPeriods().GetPeriod(phase).End : cycle.GetPeriods().GetPeriod(phase).Start;
+            var blocksToFind = periodStart - height + offset;
+            if (blocksToFind <= 0)
+                return;
+
+            node.FindBlock(blocksToFind);
+            SyncNodes();
+        }
+
+        public void RefreshWalletCache()
+        {
+            if (ClientRuntime != null)
+                ClientRuntime.Services.BlockExplorerService.WaitBlock(uint256.Zero, default(CancellationToken));
+            if (ServerRuntime != null)
+                ServerRuntime.Services.BlockExplorerService.WaitBlock(uint256.Zero, default(CancellationToken));
+        }
+
+        public TumblerClientRuntime ClientRuntime
+        {
+            get; set;
+        }
+
+        public void SyncNodes()
+        {
+            foreach (var node in NodeBuilder.Nodes)
+            {
+                foreach (var node2 in NodeBuilder.Nodes)
+                {
+                    if (node != node2)
+                        node.Sync(node2, true);
+                }
+            }
+            RefreshWalletCache();
+        }
+
+        private static bool TryDelete(string directory, bool throws)
+        {
+            try
+            {
+                Utils.DeleteRecursivelyWithMagicDust(directory);
+                return true;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return true;
+            }
+            catch (Exception)
+            {
+                if (throws)
+                    throw;
+            }
+            return false;
+        }
+
+        private readonly CoreNode _TumblerNode;
+        public CoreNode TumblerNode
+        {
+            get
+            {
+                return _TumblerNode;
+            }
+        }
+
+        private NodeBuilder _NodeBuilder;
+        public NodeBuilder NodeBuilder
+        {
+            get
+            {
+                return _NodeBuilder;
+            }
+        }
+
+        private IWebHost _Host;
+        public IWebHost Host
+        {
+            get
+            {
+                return _Host;
+            }
+        }
+
+        public Uri Address
+        {
+            get
+            {
+                var address = ((IServer)(_Host.Services.GetService(typeof(IServer)))).Features.Get<IServerAddressesFeature>().Addresses.FirstOrDefault();
+                var builder = new UriBuilder(address);
+                builder.Path = $"api/v1/tumblers/{ServerRuntime.ClassicTumblerParameters.GetHash()}";
+                return builder.Uri;
+            }
+        }
+
+        private readonly string _Directory;
+        private readonly CoreNode _AliceNode;
+        public CoreNode AliceNode
+        {
+            get
+            {
+                return _AliceNode;
+            }
+        }
+
+
+        private readonly CoreNode _BobNode;
+        public CoreNode BobNode
+        {
+            get
+            {
+                return _BobNode;
+            }
+        }
+
+        public string BaseDirectory
+        {
+            get
+            {
+                return _Directory;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_Host != null)
+            {
+
+                _Host.Dispose();
+                _Host = null;
+            }
+            if (_NodeBuilder != null)
+            {
+                _NodeBuilder.Dispose();
+                _NodeBuilder = null;
+            }
+            if (ClientRuntime != null)
+            {
+                ClientRuntime.Dispose();
+                ClientRuntime = null;
+            }
+            if (ServerRuntime != null)
+            {
+                ServerRuntime.Dispose();
+                ServerRuntime = null;
+            }
+        }
+    }
 }

--- a/NTumbleBit.Tests/TumblerServerTests.cs
+++ b/NTumbleBit.Tests/TumblerServerTests.cs
@@ -5,6 +5,7 @@ using NTumbleBit.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace NTumbleBit.Tests
@@ -23,6 +24,7 @@ namespace NTumbleBit.Tests
 				Assert.NotEqual(0, parameters.FakeTransactionCount);
 				Assert.NotNull(parameters.FakeFormat);
 				Assert.True(parameters.FakeFormat != uint256.Zero);
+				Assert.Equal(RsaKey.KeySize, parameters.VoucherKey.GetKeySize());
 			}
 		}
 
@@ -84,7 +86,6 @@ namespace NTumbleBit.Tests
 				Assert.True(tracker.Search(address3).Length == 0);
 			}
 		}
-
 
 		[Fact]
 		public void CanCompleteCycleWithMachineState()

--- a/NTumbleBit/BouncyCastle/crypto/generators/RsaKeyPairGenerator.cs
+++ b/NTumbleBit/BouncyCastle/crypto/generators/RsaKeyPairGenerator.cs
@@ -1,7 +1,4 @@
-﻿using System;
-
-using NTumbleBit.BouncyCastle.Crypto;
-using NTumbleBit.BouncyCastle.Crypto.Parameters;
+﻿using NTumbleBit.BouncyCastle.Crypto.Parameters;
 using NTumbleBit.BouncyCastle.Math;
 using NTumbleBit.BouncyCastle.Utilities;
 
@@ -108,7 +105,6 @@ namespace NTumbleBit.BouncyCastle.Crypto.Generators
 
 				BigInteger pSub1 = p.Subtract(One);
 				BigInteger qSub1 = q.Subtract(One);
-				//BigInteger phi = pSub1.Multiply(qSub1);
 				BigInteger gcd = pSub1.Gcd(qSub1);
 				BigInteger lcm = pSub1.Divide(gcd).Multiply(qSub1);
 

--- a/NTumbleBit/BouncyCastle/math/BigInteger.cs
+++ b/NTumbleBit/BouncyCastle/math/BigInteger.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
-
 using NTumbleBit.BouncyCastle.Security;
 using NTumbleBit.BouncyCastle.Utilities;
 
@@ -153,7 +152,7 @@ namespace NTumbleBit.BouncyCastle.Math
 		//    4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8
 		//};
 
-		private readonly static byte[] BitLengthTable =
+		private static readonly byte[] BitLengthTable =
 		{
 			0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4,
 			5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
@@ -233,8 +232,8 @@ namespace NTumbleBit.BouncyCastle.Math
 			}
 		}
 
-		private int[] magnitude; // array of ints with [0] being the most significant
-		private int sign; // -1 means -ve; +1 means +ve; 0 means 0;
+		private readonly int[] magnitude; // array of ints with [0] being the most significant
+		private readonly int sign; // -1 means -ve; +1 means +ve; 0 means 0;
 		private int nBits = -1; // cache BitCount() value
 		private int nBitLength = -1; // cache BitLength() value
 		private int mQuote = 0; // -m^(-1) mod b, b = 2^32 (see Montgomery mult.), 0 when uninitialised
@@ -1256,7 +1255,6 @@ namespace NTumbleBit.BouncyCastle.Math
 
 		private bool IsEqualMagnitude(BigInteger x)
 		{
-			int[] xMag = x.magnitude;
 			if(magnitude.Length != x.magnitude.Length)
 				return false;
 			for(int i = 0; i < magnitude.Length; i++)
@@ -2459,7 +2457,7 @@ namespace NTumbleBit.BouncyCastle.Math
 		public BigInteger Multiply(
 			BigInteger val)
 		{
-			if(val == this)
+			if(Equals(val, this))
 				return Square();
 
 			if((sign & val.sign) == 0)

--- a/NTumbleBit/ClassicTumbler/CLI/ClientInteractiveRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/CLI/ClientInteractiveRuntime.cs
@@ -29,7 +29,7 @@ namespace NTumbleBit.ClassicTumbler.CLI
 
 		public Tracker Tracker => InnerRuntime.Tracker;
 
-		public ExternalServices Services => InnerRuntime.Services;
+		public IExternalServices Services => InnerRuntime.Services;
 
 		public IDestinationWallet DestinationWallet => InnerRuntime.DestinationWallet;
 

--- a/NTumbleBit/ClassicTumbler/CLI/IInteractiveRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/CLI/IInteractiveRuntime.cs
@@ -22,7 +22,7 @@ namespace NTumbleBit.ClassicTumbler.CLI
 		{
 			get;
 		}
-		ExternalServices Services
+		IExternalServices Services
 		{
 			get;
 		}

--- a/NTumbleBit/ClassicTumbler/CLI/ServerInteractiveRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/CLI/ServerInteractiveRuntime.cs
@@ -28,7 +28,7 @@ namespace NTumbleBit.ClassicTumbler.CLI
 
 		public Tracker Tracker => InnerRuntime.Tracker;
 
-		public ExternalServices Services => InnerRuntime.Services;
+		public IExternalServices Services => InnerRuntime.Services;
 
 		public IDestinationWallet DestinationWallet => null;
 

--- a/NTumbleBit/ClassicTumbler/ClassicTumblerParameters.cs
+++ b/NTumbleBit/ClassicTumbler/ClassicTumblerParameters.cs
@@ -242,6 +242,8 @@ namespace NTumbleBit.ClassicTumbler
 		{
 			//TODO check RSA proof for the pubkeys
 			return
+				this.VoucherKey.GetKeySize() == RsaKey.KeySize &&
+				this.ServerKey.GetKeySize() == RsaKey.KeySize &&
 				this.FakePuzzleCount == 285 &&
 				this.RealPuzzleCount == 15 &&
 				this.RealTransactionCount == 42 &&

--- a/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
+++ b/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
@@ -302,7 +302,8 @@ namespace NTumbleBit.ClassicTumbler.Client
 						{
 							TransactionInformation tumblerTx = GetTransactionInformation(PromiseClientSession.EscrowedCoin, false);
 							//Ensure the tumbler coin is confirmed before paying anything
-							if(tumblerTx != null || tumblerTx.Confirmations >= cycle.SafetyPeriodDuration)
+
+							if(tumblerTx != null && tumblerTx.Confirmations >= cycle.SafetyPeriodDuration)
 							{
 								Logs.Client.LogInformation($"Client escrow reached {cycle.SafetyPeriodDuration} confirmations");
 

--- a/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
+++ b/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
@@ -62,7 +62,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 				return Runtime.Tracker;
 			}
 		}
-		public ExternalServices Services
+		public IExternalServices Services
 		{
 			get
 			{

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientConfigurationBase.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientConfigurationBase.cs
@@ -1,0 +1,44 @@
+﻿using NTumbleBit.ClassicTumbler.Client.ConnectionSettings;
+using NBitcoin;
+using NTumbleBit.Services;
+
+namespace NTumbleBit.ClassicTumbler.Client
+{
+    public abstract class TumblerClientConfigurationBase
+    {
+        public string DataDir { get; set; }
+
+        public Network Network { get; set; }
+
+        public bool OnlyMonitor { get; set; }
+
+        public bool CheckIp { get; set; } = true;
+
+        public bool Cooperative { get; set; }
+
+        public TumblerUrlBuilder TumblerServer { get; set; }
+
+        public ConnectionSettingsBase BobConnectionSettings { get; set; } = new ConnectionSettingsBase();
+
+        public ConnectionSettingsBase AliceConnectionSettings { get; set; } = new ConnectionSettings.ConnectionSettingsBase();
+
+        public OutputWalletConfiguration OutputWallet { get; set; } = new OutputWalletConfiguration();
+
+        public bool AllowInsecure { get; set; } = false;
+
+        public string TorPath { get; set; }
+
+        public Tracker Tracker { get; set; }
+
+        public DBreezeRepository DBreezeRepository { get; set; }
+
+        public IExternalServices Services { get; set; }
+        
+        public IDestinationWallet DestinationWallet { get; set; }
+
+        protected bool IsTest(Network network)
+        {
+            return network == Network.TestNet || network == Network.RegTest;
+        }
+    }
+}

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
@@ -242,7 +242,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 			get;
 			set;
 		}
-		public ExternalServices Services
+		public IExternalServices Services
 		{
 			get;
 			set;

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
@@ -33,12 +33,12 @@ namespace NTumbleBit.ClassicTumbler.Client
 
 	public class TumblerClientRuntime : IDisposable
 	{
-		public static TumblerClientRuntime FromConfiguration(TumblerClientConfiguration configuration, ClientInteraction interaction)
+		public static TumblerClientRuntime FromConfiguration(TumblerClientConfigurationBase configuration, ClientInteraction interaction)
 		{
 			return FromConfigurationAsync(configuration, interaction).GetAwaiter().GetResult();
 		}
 
-		public static async Task<TumblerClientRuntime> FromConfigurationAsync(TumblerClientConfiguration configuration, ClientInteraction interaction)
+		public static async Task<TumblerClientRuntime> FromConfigurationAsync(TumblerClientConfigurationBase configuration, ClientInteraction interaction)
 		{
 			TumblerClientRuntime runtime = new TumblerClientRuntime();
 			try
@@ -52,7 +52,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 			}
 			return runtime;
 		}
-		public async Task ConfigureAsync(TumblerClientConfiguration configuration, ClientInteraction interaction)
+		public async Task ConfigureAsync(TumblerClientConfigurationBase configuration, ClientInteraction interaction)
 		{
 			interaction = interaction ?? new AcceptAllClientInteraction();
 
@@ -63,43 +63,18 @@ namespace NTumbleBit.ClassicTumbler.Client
 			AllowInsecure = configuration.AllowInsecure;
 
 			await SetupTorAsync(interaction, configuration.TorPath).ConfigureAwait(false);
-
-			RPCClient rpc = null;
-			try
-			{
-				rpc = configuration.RPCArgs.ConfigureRPCClient(configuration.Network);
-			}
-			catch
-			{
-				throw new ConfigException("Please, fix rpc settings in " + configuration.ConfigurationFile);
-			}
-
-			var dbreeze = new DBreezeRepository(Path.Combine(configuration.DataDir, "db2"));
+		
 			Cooperative = configuration.Cooperative;
-			Repository = dbreeze;
-			_Disposables.Add(dbreeze);
-			Tracker = new Tracker(dbreeze, Network);
-			Services = ExternalServices.CreateFromRPCClient(rpc, dbreeze, Tracker);
+			Repository = configuration.DBreezeRepository;
+			_Disposables.Add(Repository);
+			Tracker = configuration.Tracker;
+			Services = configuration.Services;
+			DestinationWallet = configuration.DestinationWallet;
 
-			if(configuration.OutputWallet.RootKey != null && configuration.OutputWallet.KeyPath != null)
-				DestinationWallet = new ClientDestinationWallet(configuration.OutputWallet.RootKey, configuration.OutputWallet.KeyPath, dbreeze, configuration.Network);
-			else if(configuration.OutputWallet.RPCArgs != null)
-			{
-				try
-				{
-					DestinationWallet = new RPCDestinationWallet(configuration.OutputWallet.RPCArgs.ConfigureRPCClient(Network));
-				}
-				catch
-				{
-					throw new ConfigException("Please, fix outputwallet rpc settings in " + configuration.ConfigurationFile);
-				}
-			}
-			else
-				throw new ConfigException("Missing configuration for outputwallet");
 
-			TumblerParameters = dbreeze.Get<ClassicTumbler.ClassicTumblerParameters>("Configuration", configuration.ToString());
+			TumblerParameters = Repository.Get<ClassicTumbler.ClassicTumblerParameters>("Configuration", configuration.TumblerServer.ToString());
 
-			if(TumblerParameters != null && TumblerParameters.GetHash() != configuration.TumblerServer.ConfigurationHash)
+			if (TumblerParameters != null && TumblerParameters.GetHash() != configuration.TumblerServer.ConfigurationHash)
 				TumblerParameters = null;
 
 			if(!configuration.OnlyMonitor)

--- a/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs
+++ b/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs
@@ -46,7 +46,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			}
 		}
 
-		public ExternalServices Services
+		public IExternalServices Services
 		{
 			get
 			{

--- a/NTumbleBit/ClassicTumbler/Server/TumblerConfiguration.cs
+++ b/NTumbleBit/ClassicTumbler/Server/TumblerConfiguration.cs
@@ -213,31 +213,6 @@ namespace NTumbleBit.ClassicTumbler.Server
 			return config;
 		}
 
-		public static IPEndPoint ConvertToEndpoint(string str, int defaultPort)
-		{
-			var portOut = defaultPort;
-			var hostOut = "";
-			int colon = str.LastIndexOf(':');
-			// if a : is found, and it either follows a [...], or no other : is in the string, treat it as port separator
-			bool fHaveColon = colon != -1;
-			bool fBracketed = fHaveColon && (str[0] == '[' && str[colon - 1] == ']'); // if there is a colon, and in[0]=='[', colon is not 0, so in[colon-1] is safe
-			bool fMultiColon = fHaveColon && (str.LastIndexOf(':', colon - 1) != -1);
-			if(fHaveColon && (colon == 0 || fBracketed || !fMultiColon))
-			{
-				int n;
-				if(int.TryParse(str.Substring(colon + 1), out n) && n > 0 && n < 0x10000)
-				{
-					str = str.Substring(0, colon);
-					portOut = n;
-				}
-			}
-			if(str.Length > 0 && str[0] == '[' && str[str.Length - 1] == ']')
-				hostOut = str.Substring(1, str.Length - 2);
-			else
-				hostOut = str;
-			return new IPEndPoint(IPAddress.Parse(hostOut), portOut);
-		}
-
 		private void AssetConfigFileExists()
 		{
 			if(!File.Exists(ConfigurationFile))

--- a/NTumbleBit/ClassicTumbler/Server/TumblerRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Server/TumblerRuntime.cs
@@ -51,16 +51,7 @@ namespace NTumbleBit.ClassicTumbler.Server
 			ClassicTumblerParameters = conf.ClassicTumblerParameters.Clone();
 			Network = conf.Network;
 			LocalEndpoint = conf.Listen;
-			RPCClient rpcClient = null;
-			try
-			{
-				rpcClient = conf.RPC.ConfigureRPCClient(conf.Network);
-			}
-			catch
-			{
-				throw new ConfigException("Please, fix rpc settings in " + conf.ConfigurationFile);
-			}
-
+			
 			bool torConfigured = false;
 			if(conf.TorSettings != null)
 			{
@@ -170,12 +161,11 @@ namespace NTumbleBit.ClassicTumbler.Server
 			}
 			Logs.Configuration.LogInformation($"--------------------------------");
 			Logs.Configuration.LogInformation("");
-
-			var dbreeze = new DBreezeRepository(Path.Combine(conf.DataDir, "db2"));
-			Repository = dbreeze;
-			_Resources.Add(dbreeze);
-			Tracker = new Tracker(dbreeze, Network);
-			Services = ExternalServices.CreateFromRPCClient(rpcClient, dbreeze, Tracker);
+			
+			Repository = conf.DBreezeRepository;
+			_Resources.Add(Repository);
+			Tracker = conf.Tracker;
+			Services = conf.Services;
 		}
 
 		public Uri TorUri
@@ -227,7 +217,7 @@ namespace NTumbleBit.ClassicTumbler.Server
 			get;
 			set;
 		}
-		public IRepository Repository
+		public DBreezeRepository Repository
 		{
 			get;
 			set;

--- a/NTumbleBit/ClassicTumbler/Server/TumblerRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Server/TumblerRuntime.cs
@@ -202,7 +202,7 @@ namespace NTumbleBit.ClassicTumbler.Server
 			get; set;
 		}
 
-		public ExternalServices Services
+		public IExternalServices Services
 		{
 			get; set;
 		}

--- a/NTumbleBit/RsaKey.cs
+++ b/NTumbleBit/RsaKey.cs
@@ -139,6 +139,11 @@ namespace NTumbleBit
 			return privInfo.ToAsn1Object().GetEncoded();
 		}
 
+		public int GetKeySize()
+		{
+			return PubKey.GetKeySize();
+		}
+
 		internal static AlgorithmIdentifier algID = new AlgorithmIdentifier(
 					new DerObjectIdentifier("1.2.840.113549.1.1.1"), DerNull.Instance);
 		public static readonly int KeySize = 2048;

--- a/NTumbleBit/RsaPubKey.cs
+++ b/NTumbleBit/RsaPubKey.cs
@@ -141,6 +141,10 @@ namespace NTumbleBit
 			return msg.Multiply(multiplier).Mod(_Key.Modulus);
 		}
 
+		public int GetKeySize()
+		{
+			return _Key.Modulus.BitLength;
+		}
 
 		public override bool Equals(object obj)
 		{

--- a/NTumbleBit/Services/BroadcasterJob.cs
+++ b/NTumbleBit/Services/BroadcasterJob.cs
@@ -12,7 +12,7 @@ namespace NTumbleBit.Services
 {
 	public class BroadcasterJob : TumblerServiceBase
 	{
-		public BroadcasterJob(ExternalServices services)
+		public BroadcasterJob(IExternalServices services)
 		{
 			BroadcasterService = services.BroadcastService;
 			TrustedBroadcasterService = services.TrustedBroadcastService;

--- a/NTumbleBit/Services/ExternalServices.cs
+++ b/NTumbleBit/Services/ExternalServices.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace NTumbleBit.Services
 {
-	public class ExternalServices
+	public class ExternalServices : IExternalServices
     {
 		public static ExternalServices CreateFromRPCClient(RPCClient rpc, IRepository repository, Tracker tracker)
 		{

--- a/NTumbleBit/Services/IExternalServices.cs
+++ b/NTumbleBit/Services/IExternalServices.cs
@@ -1,0 +1,19 @@
+﻿
+namespace NTumbleBit.Services
+{
+	/// <summary>
+	/// Interface containing objects used for interacting with a bitcoin node.
+	/// </summary>
+	public interface IExternalServices
+	{        
+		IFeeService FeeService { get; set; }
+	
+		IWalletService WalletService { get; set; }
+
+		IBroadcastService BroadcastService { get; set; }
+		
+		IBlockExplorerService BlockExplorerService { get; set; }
+		
+		ITrustedBroadcastService TrustedBroadcastService { get; set; }
+	}
+}


### PR DESCRIPTION
I created parent classes for ExternalServices and TumblerClientConfiguration so that a custom config can be used with the TumblerClientRuntime, without having any dependency on RPC or any configuration file.
This will be particularly useful for the Breeze Client as it doesn't have access to a Bitcoin Core node and won't be using a configuration file to initialize the runtime.
More on this can be found here:
https://github.com/NTumbleBit/NTumbleBit/pull/82/